### PR TITLE
specify yarn version 1.22.1

### DIFF
--- a/.gitignore
+++ b/.gitignore
@@ -7,3 +7,6 @@ __pycache__
 v-env
 .DS_Store
 yarn.lock
+
+.yarn/*
+!.yarn/releases

--- a/.yarnrc.yml
+++ b/.yarnrc.yml
@@ -1,0 +1,1 @@
+yarnPath: .yarn/releases/yarn-1.22.1.cjs

--- a/package.json
+++ b/package.json
@@ -14,5 +14,5 @@
     "dev:workers": "cd workers && ./dev_entrypoint.sh",
     "lint": "cd backend && yarn lint && cd ../frontend && yarn lint && cd ../workers && yarn lint"
   },
-  "private": false
+  "packageManager": "yarn@1.22.1"
 }


### PR DESCRIPTION
This specifies the yarn version to `1.22.1` so there are no problems on systems where are newer version of yarn is used.
See: https://github.com/Mintplex-Labs/vector-admin/issues/22