### PR TITLE
Semantic search document filtering

### DIFF
--- a/backend/utils/search/documentEmbeddings/semantic.js
+++ b/backend/utils/search/documentEmbeddings/semantic.js
@@ -42,7 +42,7 @@ async function semanticSearch(document, query) {
     .map((vid) => `'${vid}'`)
     .join(",");
   const fragments = await DocumentVectors.where(
-    `vectorId IN (${searchString})`,
+    `vectorId IN (${searchString}) AND document_id = ${document.id}`,
     100
   );
   return { fragments, error: null };

--- a/frontend/src/pages/DocumentView/FragmentList/MetadataEditor/index.tsx
+++ b/frontend/src/pages/DocumentView/FragmentList/MetadataEditor/index.tsx
@@ -74,7 +74,7 @@ const MetadataEditor = memo(
               non-embedded information.
             </p>
 
-            {connector.type === 'weaviate' && (
+            {connector?.type === 'weaviate' && (
               <div className="flex w-full items-center justify-center gap-x-2 rounded-lg border border-orange-600 bg-orange-50 px-4 py-2 text-lg text-orange-800">
                 <AlertTriangle size={18} />
                 <p>
@@ -96,7 +96,7 @@ const MetadataEditor = memo(
               onChange={setHasChanges}
               metadata={editableMetadata}
               canEdit={canEdit}
-              canDelete={connector.type !== 'weaviate'}
+              canDelete={connector?.type !== 'weaviate'}
             />
             <NewEntry addKeyPair={addNewKeyValue} />
 


### PR DESCRIPTION
Fix issue where semantic search in a single document will include fragments from the workspace in total and not limited to the focused document