### PR TITLE
rely on provider for counting of vectors and only optionally fallback on DB due to slow query

### DIFF
--- a/backend/endpoints/v1/workspaces/index.js
+++ b/backend/endpoints/v1/workspaces/index.js
@@ -303,10 +303,10 @@ function workspaceEndpoints(app) {
           return;
         }
 
-        console.log(workspace);
         const value = await WorkspaceDocument[methods[statistic]](
           "workspace_id",
-          workspace.id
+          workspace.id,
+          workspace.slug
         );
         response.status(200).json({ value });
       } catch (e) {

--- a/backend/utils/vectordatabases/providers/chroma/index.js
+++ b/backend/utils/vectordatabases/providers/chroma/index.js
@@ -51,8 +51,17 @@ class Chroma {
     return { result: await client.heartbeat(), error: null };
   }
 
-  async totalIndicies() {
+  async totalIndicies(filterByNamespace = null) {
     const { client } = await this.connect();
+
+    if (!!filterByNamespace) {
+      const collection = await client
+        .getCollection({ name: filterByNamespace })
+        .catch(() => null);
+      if (!collection) return 0;
+      return { result: await collection.count(), error: null };
+    }
+
     const collections = await client.listCollections();
     var totalVectors = 0;
     for (const collectionObj of collections) {

--- a/backend/utils/vectordatabases/providers/index.js
+++ b/backend/utils/vectordatabases/providers/index.js
@@ -1,29 +1,28 @@
-const {
-  OrganizationConnection,
-} = require("../../../models/organizationConnection");
-const { Chroma } = require("./chroma");
-const { Pinecone } = require("./pinecone");
-const { QDrant } = require("./qdrant");
-const { Weaviate } = require("./weaviate");
-
 function selectConnector(organizationConnector) {
+  const {
+    OrganizationConnection,
+  } = require("../../../models/organizationConnection");
   const { type } = organizationConnector;
 
   if (!OrganizationConnection.supportedConnectors.includes(type))
     throw new Error("Unsupported connector for vector database.");
   if (organizationConnector.type === "chroma") {
+    const { Chroma } = require("./chroma");
     return new Chroma(organizationConnector);
   }
 
   if (organizationConnector.type === "pinecone") {
+    const { Pinecone } = require("./pinecone");
     return new Pinecone(organizationConnector);
   }
 
   if (organizationConnector.type === "qdrant") {
+    const { QDrant } = require("./qdrant");
     return new QDrant(organizationConnector);
   }
 
   if (organizationConnector.type === "weaviate") {
+    const { Weaviate } = require("./weaviate");
     return new Weaviate(organizationConnector);
   }
 

--- a/backend/utils/vectordatabases/providers/pinecone/index.js
+++ b/backend/utils/vectordatabases/providers/pinecone/index.js
@@ -100,9 +100,19 @@ class Pinecone {
       });
   }
 
-  async totalIndicies() {
+  async totalIndicies(filterByNamespace = null) {
     const { pineconeIndex } = await this.connect();
     const { namespaces } = await pineconeIndex.describeIndexStats1();
+
+    if (!!filterByNamespace) {
+      if (!namespaces.hasOwnProperty(filterByNamespace))
+        return { result: 0, error: null };
+      return {
+        result: namespaces[filterByNamespace].vectorCount || 0,
+        error: null,
+      };
+    }
+
     const totalVectors = Object.values(namespaces).reduce(
       (a, b) => a + (b?.vectorCount || 0),
       0

--- a/backend/utils/vectordatabases/providers/qdrant/index.js
+++ b/backend/utils/vectordatabases/providers/qdrant/index.js
@@ -43,12 +43,15 @@ class QDrant {
     return Number(collection?.config?.params?.vectors?.size || 0);
   }
 
-  async totalIndicies() {
+  async totalIndicies(filterByNamespace = null) {
     const { client } = await this.connect();
     const { collections } = await client.getCollections();
     var totalVectors = 0;
     for (const collection of collections) {
       if (!collection || !collection.name) continue;
+      if (!!filterByNamespace && filterByNamespace !== collection.name)
+        continue;
+
       totalVectors +=
         (await this.namespaceWithClient(client, collection.name))
           ?.vectorCount || 0;

--- a/backend/utils/vectordatabases/providers/weaviate/index.js
+++ b/backend/utils/vectordatabases/providers/weaviate/index.js
@@ -60,13 +60,15 @@ class Weaviate {
     );
   }
 
-  async totalIndicies() {
+  async totalIndicies(filterByNamespace = null) {
     const { client } = await this.connect();
     const collections = await this.collections();
     var totalVectors = 0;
     for (const collection of collections) {
       if (!collection || !collection.name) continue;
-      console.log({ dim: await this.indexDimensions(collection.name) });
+      if (!!filterByNamespace && filterByNamespace !== collection.name)
+        continue;
+
       totalVectors +=
         (await this.namespaceWithClient(client, collection.name))
           ?.vectorCount || 0;


### PR DESCRIPTION
Until the data migration is done and `organiztion_id` is appended to `document vectors` we will need to rely on the provider for counting vectors.

1. This can count documents or vectors that VectorAdmin isn't aware of because we are reading from remote
2. The SQL query currently used is not great and with 50K documents results in an even larger `...IN(1,2,3,)` query looking for document ids that are in `document_vectors` and would be easier to have a fixed `organization_id` key we can `COUNT` against since we will very easily reach the upper end of `IN()` parameters