### PR TITLE
Update index.tsx

### DIFF
--- a/frontend/src/pages/DocumentView/FragmentList/index.tsx
+++ b/frontend/src/pages/DocumentView/FragmentList/index.tsx
@@ -211,7 +211,7 @@ const Fragment = ({
         </th>
         <td className="px-6 py-4">{fragment.vectorId}</td>
         <td className="px-6 py-4">
-          {truncate(data?.metadata?.text, 40)}
+          {data?.metadata?.text ? truncate(data?.metadata?.text, 40) : 'no text found.'}
           {!!data?.metadata?.text ? (
             <button
               className="text-blue-400"


### PR DESCRIPTION
Seemed to be calling truncate regardless of whether the property was present which caused truncate to call .length against a null, do not have running locally so could not verify in browser if the change was correct, i created a issue for it https://github.com/Mintplex-Labs/vector-admin/issues/65 please verify if my guess was correct. I called an if against that property (data.metadata.text) and just provided place holder text matching the string below if a falsy value was found. Hope i could help.