### PR TITLE
21 support no namespace pinecone

### DIFF
--- a/backend/models/organizationWorkspace.js
+++ b/backend/models/organizationWorkspace.js
@@ -53,7 +53,11 @@ const OrganizationWorkspace = {
     }
   },
 
-  create: async function (workspaceName = "", organizationId = 0) {
+  create: async function (
+    workspaceName = "",
+    organizationId = 0,
+    presetFName = null
+  ) {
     try {
       if (!workspaceName)
         return { workspace: null, message: "No Workspace name provided." };
@@ -69,7 +73,7 @@ const OrganizationWorkspace = {
         data: {
           name: workspaceName,
           slug,
-          fname: workspaceName,
+          fname: presetFName ?? workspaceName,
           uuid: this.makeKey(),
           organization_id: Number(organizationId),
         },

--- a/backend/utils/jobs/cloneDocumentJob/index.js
+++ b/backend/utils/jobs/cloneDocumentJob/index.js
@@ -1,4 +1,5 @@
 const { Queue } = require("../../../models/queue");
+const { selectConnector } = require("../../vectordatabases/providers");
 
 async function cloneDocumentJob(
   organization,
@@ -9,6 +10,15 @@ async function cloneDocumentJob(
 ) {
   const taskName = `${connector.type}/cloneDocument`;
   const jobData = { organization, workspace, document, connector };
+  const vectorDBClient = selectConnector(connector);
+
+  if (vectorDBClient.name === "pinecone" && vectorDBClient.isStarterTier()) {
+    return {
+      job: null,
+      error: `Your Pinecone index does not allow namespace creation so you cannot perform this action.`,
+    };
+  }
+
   const { job, error } = await Queue.create(
     taskName,
     jobData,

--- a/backend/utils/jobs/newWorkspaceJob/index.js
+++ b/backend/utils/jobs/newWorkspaceJob/index.js
@@ -1,8 +1,18 @@
 const { Queue } = require("../../../models/queue");
+const { selectConnector } = require("../../vectordatabases/providers");
 
 async function newWorkspaceJob(organization, workspace, connector, user) {
   const taskName = `workspace/new`;
   const jobData = { organization, workspace, connector };
+  const vectorDBClient = selectConnector(connector);
+
+  if (vectorDBClient.name === "pinecone" && vectorDBClient.isStarterTier()) {
+    return {
+      job: null,
+      error: `Your Pinecone index does not allow namespace creation so you cannot perform this action.`,
+    };
+  }
+
   const { job, error } = await Queue.create(
     taskName,
     jobData,

--- a/frontend/src/models/workspace.ts
+++ b/frontend/src/models/workspace.ts
@@ -26,7 +26,7 @@ const Workspace = {
         return null;
       });
 
-    if (!workspace) return { organization: null, error };
+    if (!workspace) return { workspace: null, error };
     return { workspace, error: null };
   },
   createAndImport: async (orgSlug: string, workspaceName: string) => {

--- a/frontend/src/pages/Dashboard/WorkspacesList/CreateWorkspaceModal/index.tsx
+++ b/frontend/src/pages/Dashboard/WorkspacesList/CreateWorkspaceModal/index.tsx
@@ -16,10 +16,12 @@ export default function CreateWorkspaceModal({
   const [searching, setSearching] = useState(false);
   const [match, setMatch] = useState(null);
   const [imported, setImported] = useState(false);
+  const [error, setError] = useState(null);
 
   const searchForNamespace = async (e: any) => {
     setMatch(null);
     setSearching(true);
+    setError(null);
     const { match } = await Organization.vectorDBExists(
       organization.slug,
       e.target.value
@@ -32,6 +34,7 @@ export default function CreateWorkspaceModal({
     if (!match) return false;
     e.preventDefault();
     setLoading(true);
+    setError(null);
     const { workspace } = await Workspace.createAndImport(
       organization.slug,
       match
@@ -48,12 +51,14 @@ export default function CreateWorkspaceModal({
   const handleSubmit = async (e: any) => {
     e.preventDefault();
     setLoading(true);
-    const { workspace } = await Workspace.createNew(
+    setError(null);
+    const { workspace, error } = await Workspace.createNew(
       organization.slug,
       e.target.name.value
     );
     if (!workspace) {
       setLoading(false);
+      setError(error);
       return false;
     }
 
@@ -116,6 +121,11 @@ export default function CreateWorkspaceModal({
                 onChange={debouncedOnChange}
                 className="w-full rounded border-[1.5px] border-stroke bg-transparent px-5 py-3 font-medium outline-none transition focus:border-primary active:border-primary disabled:cursor-default disabled:bg-whiter dark:border-form-strokedark dark:bg-form-input dark:focus:border-primary"
               />
+              {error && (
+                <p className="my-1 rounded-lg border border-red-800 bg-red-600/10 p-1 px-2 text-sm text-red-600">
+                  Error: {error}
+                </p>
+              )}
             </div>
             <div className="flex flex-col gap-y-2">
               {!match ? (
@@ -130,6 +140,7 @@ export default function CreateWorkspaceModal({
                   <button
                     type="button"
                     onClick={() => {
+                      setError(null);
                       document
                         .getElementById('workspace-creation-modal')
                         ?.close();
@@ -167,10 +178,6 @@ export default function CreateWorkspaceModal({
                 </>
               )}
             </div>
-            <p className="my-2 rounded-lg border border-orange-800 bg-orange-100 p-2 text-center text-sm text-orange-800">
-              Once your workspace exists you can start adding documents via the
-              UI or API via code.
-            </p>
           </div>
         </form>
       )}

--- a/frontend/src/pages/Tools/MigrateConnection/index.tsx
+++ b/frontend/src/pages/Tools/MigrateConnection/index.tsx
@@ -281,13 +281,21 @@ function DestinationOrgCard({
   );
 }
 
+interface IDestination {
+  name: string;
+  connector: {
+    type: 'pinecone' | 'chroma' | 'qdrant' | 'weaviate';
+    settings: string;
+  };
+}
+
 function SubmitMigrationJob({
   organization,
   destination,
   totalVectorCount,
 }: {
   organization: any;
-  destination: any;
+  destination: IDestination;
   totalVectorCount: number;
 }) {
   const [status, setStatus] = useState<
@@ -333,6 +341,17 @@ function SubmitMigrationJob({
 
   return (
     <div className="mt-2 flex flex-col gap-y-1">
+      {isIneligibleConnector(destination) && (
+        <div className="my-2 flex flex-col gap-y-1">
+          <p className="mx-auto w-full rounded-lg bg-red-600/20 p-2 text-center text-sm text-red-800">
+            Namespace support for Pinecone db "{destination.name}" is not
+            supported.
+            <br />
+            Migration of namespaced data will not succeed.
+          </p>
+        </div>
+      )}
+
       <button
         onClick={submitMigration}
         className="full rounded-lg bg-blue-600 px-4 py-2 font-semibold text-white hover:bg-blue-700"
@@ -347,4 +366,12 @@ function SubmitMigrationJob({
       </p>
     </div>
   );
+}
+
+function isIneligibleConnector(destination?: IDestination) {
+  if (!destination) return false;
+  if (destination.connector.type !== 'pinecone') return false;
+
+  const { environment } = JSON.parse(destination.connector.settings);
+  return environment === 'gcp-starter';
 }

--- a/workers/functions/syncPineconeWorkspace/index.js
+++ b/workers/functions/syncPineconeWorkspace/index.js
@@ -143,6 +143,22 @@ async function paginateAndStore(
       files[documentName].currentLine =
         files[documentName].currentLine + 1 + totalLines;
     }
+
+    // When on the free starter tier upserts can be delayed anywhere from 10 - 60 seconds.
+    // So we need to sleep for this entire loop to ensure the RunID was saved + indexed.
+    // Ref: https://docs.pinecone.io/docs/starter-environment#limitations
+    if (pineconeClient.isStarterTier()) {
+      console.log(
+        `\x1b[34m[Sync Notice]\x1b[0m Pinecone Starter Tier detected - need to sleep ${pineconeClient.STARTER_TIER_UPSERT_DELAY}ms between upserts.`,
+        {
+          pineconeDocsLink:
+            'https://docs.pinecone.io/docs/starter-environment#limitations',
+        }
+      );
+      await new Promise((r) =>
+        setTimeout(r, pineconeClient.STARTER_TIER_UPSERT_DELAY)
+      );
+    }
   }
 
   console.log('Removing existing Workspace Documents & Document Vectors');


### PR DESCRIPTION
- Allow sync with pinecone `gcp-starter`
- Allow migration of data from/into starter tier pinecone
- Show alert for namespace availability when migrating into starter tier pinecone
- Allow sync of `no-namespace` namespace for all pinecone tiers

resolves #21 