### PR TITLE
Fix org deletion redirection path

### DIFF
--- a/frontend/src/pages/OrganizationSettings/Settings/index.tsx
+++ b/frontend/src/pages/OrganizationSettings/Settings/index.tsx
@@ -42,7 +42,7 @@ export default function OrgSettings({ organization }: { organization: any }) {
       return;
     }
 
-    window.location.replace(paths.home());
+    window.location.replace(paths.dashboard());
   };
 
   return (


### PR DESCRIPTION
On deletion of an organization from VA - bring to dashboard and not to /home