### PR TITLE
Fix "documents" typo in upload modal

### DIFF
--- a/frontend/src/pages/Dashboard/DocumentsList/UploadModal/UploadModalNoKey.tsx
+++ b/frontend/src/pages/Dashboard/DocumentsList/UploadModal/UploadModalNoKey.tsx
@@ -57,7 +57,7 @@ export default function UploadModalNoKey() {
               </div>
             </div>
             <p className="my-2 p-2 text-center text-sm text-orange-800">
-              This key will only be used for the embedding of documnets you
+              This key will only be used for the embedding of documents you
               upload via {APP_NAME}.
             </p>
           </form>

--- a/frontend/src/pages/WorkspaceDashboard/DocumentsList/UploadModal/UploadModalNoKey.tsx
+++ b/frontend/src/pages/WorkspaceDashboard/DocumentsList/UploadModal/UploadModalNoKey.tsx
@@ -57,7 +57,7 @@ export default function UploadModalNoKey() {
               </div>
             </div>
             <p className="my-2 p-2 text-center text-sm text-orange-800">
-              This key will only be used for the embedding of documnets you
+              This key will only be used for the embedding of documents you
               upload via {APP_NAME}.
             </p>
           </form>


### PR DESCRIPTION
It fixes the "documents" typo in upload modal

![2023-12-01 at 21 06 33@2x](https://github.com/Mintplex-Labs/vector-admin/assets/4201088/95c65699-68a0-4543-9b97-879e5296c4ed)

----

@timothycarambat Great work with Vector-admin and AnythingLLM 🙌