### PR TITLE
typo-fix in backend/.env.example which is causing `yarn prisma:setup` to crash

### DIFF
--- a/backend/.env.example
+++ b/backend/.env.example
@@ -6,4 +6,4 @@ SYS_PASSWORD=password
 
 JWT_SECRET="YoUr_RaNd0M_sTr1nG"
 # STORAGE_DIR=
-DATABASE_CONNECTION_STRING="postgresql://user:password@host:port/database
+DATABASE_CONNECTION_STRING="postgresql://user:password@host:port/database"


### PR DESCRIPTION
 ### Pull Request Type

<!-- For change type, change [ ] to [x]. -->

- [ ] ✨ feat
- [ x] 🐛 fix
- [ ] ♻️ refactor
- [ ] 💄 style
- [ ] 🔨 chore
- [ ] 📝 docs

### Relevant Issues

<!-- Use "resolves #xxx" to auto resolve on merge. Otherwise, please use "connect #xxx" -->


### What is in this change?

simple typo fix in backend/.env.example file which is causing the  `yarn prisma:setup` to crash


### Additional Information

### Developer Validations

<!-- All of the applicable items should be checked. -->

- [ x] I ran `yarn lint` from the root of the repo & committed changes
- [ ] Relevant documentation has been updated (No Need)
- [ x] I have tested my code functionality
- [ x] Docker build succeeds locally
