### PR TITLE
Upgrade Pinecone

### DIFF
--- a/backend/package.json
+++ b/backend/package.json
@@ -14,7 +14,7 @@
     "lint": "yarn prettier --write ./endpoints ./models ./utils index.js"
   },
   "dependencies": {
-    "@pinecone-database/pinecone": "^0.1.6",
+    "@pinecone-database/pinecone": "^2.2.2",
     "@prisma/client": "^5.3.1",
     "@qdrant/js-client-rest": "^1.5.0",
     "bcrypt": "^5.1.0",
@@ -33,7 +33,7 @@
     "multer": "^1.4.5-lts.1",
     "openai": "^3.3.0",
     "pg": "^8.11.3",
-    "pinecone-client": "^1.1.0",
+    "pinecone-client": "^2.0.0",
     "posthog-node": "^3.1.2",
     "prisma": "^5.3.1",
     "slugify": "^1.6.6",

--- a/backend/utils/vectordatabases/providers/pinecone/index.js
+++ b/backend/utils/vectordatabases/providers/pinecone/index.js
@@ -27,17 +27,13 @@ class Pinecone {
   }
 
   async connect() {
-    const { PineconeClient } = require("@pinecone-database/pinecone");
+    const { Pinecone } = require("@pinecone-database/pinecone");
     const { type, settings } = this.config;
 
     if (type !== "pinecone")
       throw new Error("Pinecone::Invalid Not a Pinecone connector instance.");
 
-    const client = new PineconeClient();
-    await client.init({
-      apiKey: settings.apiKey,
-      environment: settings.environment,
-    });
+    const client = new Pinecone({ apiKey: settings.apiKey });
 
     const pineconeIndex = client.Index(settings.index);
     const {
@@ -76,7 +72,7 @@ class Pinecone {
     //     }
     // }
     return await fetch(
-      `https://controller.${settings.environment}.pinecone.io/databases/${settings.index}`,
+      `https://api.pinecone.io/indexes/${settings.index}`,
       {
         method: "GET",
         headers: {

--- a/backend/utils/vectordatabases/validateNewDatabaseConnector.js
+++ b/backend/utils/vectordatabases/validateNewDatabaseConnector.js
@@ -66,13 +66,9 @@ async function validateChroma({
 }
 
 async function validatePinecone({ environment, index, apiKey }) {
-  const { PineconeClient } = require("@pinecone-database/pinecone");
+  const { Pinecone } = require("@pinecone-database/pinecone");
   try {
-    const client = new PineconeClient();
-    await client.init({
-      apiKey,
-      environment,
-    });
+    const client = new Pinecone({ apiKey });
     const { status } = await client.describeIndex({
       indexName: index,
     });

--- a/backend/yarn.lock
+++ b/backend/yarn.lock
@@ -87,12 +87,15 @@
     mkdirp "^1.0.4"
     rimraf "^3.0.2"
 
-"@pinecone-database/pinecone@^0.1.6":
-  version "0.1.6"
-  resolved "https://registry.yarnpkg.com/@pinecone-database/pinecone/-/pinecone-0.1.6.tgz#13374ae9462c8eea0dc26683cafeddc4e7c0375f"
-  integrity sha512-tCnVc28udecthhgSBTdcMhYEW+xsR++AdZasp+ZE/AvUD1hOR2IR3edjk9m0sDxZyvXbno2KeqUbLIOZr7sCTw==
+"@pinecone-database/pinecone@^2.2.2":
+  version "2.2.2"
+  resolved "https://registry.yarnpkg.com/@pinecone-database/pinecone/-/pinecone-2.2.2.tgz#1040efd09b76463a46e91dea35bb61b7a4351769"
+  integrity sha512-gbe/4SowHc64pHIm0kBdgY9hVdzsQnnnpcWviwYMB33gOmsL8brvE8fUSpl1dLDvdyXzKcQkzdBsjCDlqgpdMA==
   dependencies:
+    "@sinclair/typebox" "^0.29.0"
+    ajv "^8.12.0"
     cross-fetch "^3.1.5"
+    encoding "^0.1.13"
 
 "@prisma/client@^5.3.1":
   version "5.3.1"
@@ -129,6 +132,11 @@
   version "0.5.0"
   resolved "https://registry.yarnpkg.com/@sevinf/maybe/-/maybe-0.5.0.tgz#e59fcea028df615fe87d708bb30e1f338e46bb44"
   integrity sha512-ARhyoYDnY1LES3vYI0fiG6e9esWfTNcXcO6+MPJJXcnyMV3bim4lnFt45VXouV7y82F4x3YH8nOQ6VztuvUiWg==
+
+"@sinclair/typebox@^0.29.0":
+  version "0.29.6"
+  resolved "https://registry.yarnpkg.com/@sinclair/typebox/-/typebox-0.29.6.tgz#4cd8372f9247372edd5fc5af44f67e2032c46e2f"
+  integrity sha512-aX5IFYWlMa7tQ8xZr3b2gtVReCvg7f3LEhjir/JAjX2bJCMVJA5tIPv30wTD4KDfcwMd7DDYY3hFDeGmOgtrZQ==
 
 "@tootallnate/once@1":
   version "1.1.2"
@@ -204,6 +212,16 @@ aggregate-error@^3.0.0:
   dependencies:
     clean-stack "^2.0.0"
     indent-string "^4.0.0"
+
+ajv@^8.12.0:
+  version "8.16.0"
+  resolved "https://registry.yarnpkg.com/ajv/-/ajv-8.16.0.tgz#22e2a92b94f005f7e0f9c9d39652ef0b8f6f0cb4"
+  integrity sha512-F0twR8U1ZU67JIEtekUcLkXkoO5mMMmgGD8sK/xUFzJ805jxHQl92hImFAqqXMyMYjSPOyUPAwHYhB72g5sTXw==
+  dependencies:
+    fast-deep-equal "^3.1.3"
+    json-schema-traverse "^1.0.0"
+    require-from-string "^2.0.2"
+    uri-js "^4.4.1"
 
 ansi-regex@^5.0.1:
   version "5.0.1"
@@ -739,7 +757,7 @@ encodeurl@~1.0.2:
   resolved "https://registry.yarnpkg.com/encodeurl/-/encodeurl-1.0.2.tgz#ad3ff4c86ec2d029322f5a02c3a9a606c95b3f59"
   integrity sha512-TPJXq8JqFaVYm2CWmPvnP2Iyo4ZSM7/QKcSmuMLDObfpH5fi7RUGmd/rTDf+rut/saiDiQEeVTNgAmJEdAOx0w==
 
-encoding@^0.1.12:
+encoding@^0.1.12, encoding@^0.1.13:
   version "0.1.13"
   resolved "https://registry.yarnpkg.com/encoding/-/encoding-0.1.13.tgz#56574afdd791f54a8e9b2785c0582a2d26210fa9"
   integrity sha512-ETBauow1T35Y/WZMkio9jiM0Z5xjHHmJ4XmjZOq1l/dXz3lr2sRn87nJy20RupqSh1F2m3HHPSp8ShIPQJrJ3A==
@@ -841,6 +859,11 @@ extract-files@^9.0.0:
   version "9.0.0"
   resolved "https://registry.yarnpkg.com/extract-files/-/extract-files-9.0.0.tgz#8a7744f2437f81f5ed3250ed9f1550de902fe54a"
   integrity sha512-CvdFfHkC95B4bBBk36hcEmvdR2awOdhhVUYH6S/zrVj3477zven/fJMYg7121h4T1xHZC+tetUpubpAhxwI7hQ==
+
+fast-deep-equal@^3.1.3:
+  version "3.1.3"
+  resolved "https://registry.yarnpkg.com/fast-deep-equal/-/fast-deep-equal-3.1.3.tgz#3a7d56b559d6cbc3eb512325244e619a65c6c525"
+  integrity sha512-f3qQ9oQy9j2AhBe/H9VC91wLmKBCCU/gDOnKNAYG5hswO7BLKj09Hc5HYNz9cGI++xlpDCIgDaitVs03ATR84Q==
 
 fill-range@^7.0.1:
   version "7.0.1"
@@ -1243,6 +1266,11 @@ js-yaml@^4.1.0:
   dependencies:
     argparse "^2.0.1"
 
+json-schema-traverse@^1.0.0:
+  version "1.0.0"
+  resolved "https://registry.yarnpkg.com/json-schema-traverse/-/json-schema-traverse-1.0.0.tgz#ae7bcb3656ab77a73ba5c49bf654f38e6b6860e2"
+  integrity sha512-NM8/P9n3XjXhIZn1lLhkFaACTOURQXjWhV4BA/RnOv8xvgqtqpAX9IO4mRQxSx1Rlo4tqzeqb0sOlruaOy3dug==
+
 jsonpointer@^5.0.1:
   version "5.0.1"
   resolved "https://registry.yarnpkg.com/jsonpointer/-/jsonpointer-5.0.1.tgz#2110e0af0900fd37467b5907ecd13a7884a1b559"
@@ -1281,10 +1309,10 @@ jws@^3.2.2:
     jwa "^1.4.1"
     safe-buffer "^5.0.1"
 
-ky@^0.33.1:
-  version "0.33.3"
-  resolved "https://registry.yarnpkg.com/ky/-/ky-0.33.3.tgz#bf1ad322a3f2c3428c13cfa4b3af95e6c4a2f543"
-  integrity sha512-CasD9OCEQSFIam2U8efFK81Yeg8vNMTBUqtMOHlrcWQHqUX3HeCl9Dr31u4toV7emlH8Mymk5+9p0lL6mKb/Xw==
+ky@^1.1.0:
+  version "1.4.0"
+  resolved "https://registry.yarnpkg.com/ky/-/ky-1.4.0.tgz#68b4a71eccfb4177199fe6ee2d5041b50bb41931"
+  integrity sha512-tPhhoGUiEiU/WXR4rt8klIoLdnTtyu+9jVKHd/wauEjYud32jyn63mzKWQweaQrHWxBQtYoVtdcEnYX1LosnFQ==
 
 langchain@^0.0.107:
   version "0.0.107"
@@ -1907,12 +1935,12 @@ picomatch@^2.0.4, picomatch@^2.2.1:
   resolved "https://registry.yarnpkg.com/picomatch/-/picomatch-2.3.1.tgz#3ba3833733646d9d3e4995946c1365a67fb07a42"
   integrity sha512-JU3teHTNjmE2VCGFzuY8EXzCDVwEqB2a8fsIvwaStHhAWJEeVd1o1QD80CU6+ZdEXXSLbSsuLwJjkCBWqRQUVA==
 
-pinecone-client@^1.1.0:
-  version "1.1.1"
-  resolved "https://registry.yarnpkg.com/pinecone-client/-/pinecone-client-1.1.1.tgz#d19bafda1a46a8d1998411ba1a3933531f66fe4f"
-  integrity sha512-wqfo08LW+9k1XkP4wNBo37qtrUSy8QwZTev1epUpTIw+jRkzH+XefgRcWqnZbotYJZxggfualL+aPoGo6BAqYQ==
+pinecone-client@^2.0.0:
+  version "2.0.0"
+  resolved "https://registry.yarnpkg.com/pinecone-client/-/pinecone-client-2.0.0.tgz#e3e2db597ddd4e1ca161d643eac80ebaa9e0f266"
+  integrity sha512-CxpKuck4zxi/LaGaTrnWQNs9NmXiMB3UtynOhD6dVDoWRKGEXmgRbSFipMUdqGyyQEKMFXzTKvzo4qMHi2Gj8Q==
   dependencies:
-    ky "^0.33.1"
+    ky "^1.1.0"
 
 postgres-array@~2.0.0:
   version "2.0.0"
@@ -1992,6 +2020,11 @@ pstree.remy@^1.1.8:
   resolved "https://registry.yarnpkg.com/pstree.remy/-/pstree.remy-1.1.8.tgz#c242224f4a67c21f686839bbdb4ac282b8373d3a"
   integrity sha512-77DZwxQmxKnu3aR542U+X8FypNzbfJ+C5XQDk3uWjWxn6151aIMGthWYRXTqT1E5oJvg+ljaa2OJi+VfvCOQ8w==
 
+punycode@^2.1.0:
+  version "2.3.1"
+  resolved "https://registry.yarnpkg.com/punycode/-/punycode-2.3.1.tgz#027422e2faec0b25e1549c3e1bd8309b9133b6e5"
+  integrity sha512-vYt7UD1U9Wg6138shLtLOvdAu+8DsC/ilFtEVHcH+wydcSpNE20AfSOduf6MkRFahL5FY7X1oU7nKVZFtfq8Fg==
+
 qs@6.11.0:
   version "6.11.0"
   resolved "https://registry.yarnpkg.com/qs/-/qs-6.11.0.tgz#fd0d963446f7a65e1367e01abd85429453f0c37a"
@@ -2062,6 +2095,11 @@ readdirp@~3.6.0:
   integrity sha512-hOS089on8RduqdbhvQ5Z37A0ESjsqz6qnRcffsMU3495FuTdqSm+7bhJ29JvIOsBDEEnan5DPu9t3To9VRlMzA==
   dependencies:
     picomatch "^2.2.1"
+
+require-from-string@^2.0.2:
+  version "2.0.2"
+  resolved "https://registry.yarnpkg.com/require-from-string/-/require-from-string-2.0.2.tgz#89a7fdd938261267318eafe14f9c32e598c36909"
+  integrity sha512-Xf0nWe6RseziFMu+Ap9biiUbmplq6S9/p+7w7YXP/JBHhrUDDUhwa+vANyubuqfZWTveU//DYVGsDG7RKL/vEw==
 
 retry@^0.12.0:
   version "0.12.0"
@@ -2407,6 +2445,13 @@ unpipe@1.0.0, unpipe@~1.0.0:
   version "1.0.0"
   resolved "https://registry.yarnpkg.com/unpipe/-/unpipe-1.0.0.tgz#b2bf4ee8514aae6165b4817829d21b2ef49904ec"
   integrity sha512-pjy2bYhSsufwWlKwPc+l3cN7+wuJlK6uz0YdJEOlQDbl6jo/YlPi4mb8agUkVC8BF7V8NuzeyPNqRksA3hztKQ==
+
+uri-js@^4.4.1:
+  version "4.4.1"
+  resolved "https://registry.yarnpkg.com/uri-js/-/uri-js-4.4.1.tgz#9b1a52595225859e55f669d928f88c6c57f2a77e"
+  integrity sha512-7rKUyy33Q1yc98pQ1DAmLtwX109F7TIfWlW1Ydo8Wl1ii1SeHieeh0HHfPeL2fMXK6z0s8ecKs9frCuLJvndBg==
+  dependencies:
+    punycode "^2.1.0"
 
 util-deprecate@^1.0.1, util-deprecate@~1.0.1:
   version "1.0.2"


### PR DESCRIPTION
 ### Pull Request Type

<!-- For change type, change [ ] to [x]. -->

- [x] ✨ feat
- [ ] 🐛 fix
- [ ] ♻️ refactor
- [ ] 💄 style
- [ ] 🔨 chore
- [ ] 📝 docs

### Relevant Issues

<!-- Use "resolves #xxx" to auto resolve on merge. Otherwise, please use "connect #xxx" -->

resolves #129


### What is in this change?

Pinecone is upgraded to a newer version. 

### Additional Information

This is to enable VectorAdmin to work with Pinecone Serverless indexes. 

Add any other context about the Pull Request here that was not captured above.

This is a WIP - I was unable to get past logging in :\ even with root@vectoradmin lol 

### Developer Validations

<!-- All of the applicable items should be checked. -->

- [ ] I ran `yarn lint` from the root of the repo & committed changes
- [ ] Relevant documentation has been updated
- [ ] I have tested my code functionality
- [ ] Docker build succeeds locally
